### PR TITLE
chore: add semgrep whitelist to reduce noise; add gitlab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,2 @@
+stages:
+  - test

--- a/.gitlab/sast-ruleset.toml
+++ b/.gitlab/sast-ruleset.toml
@@ -1,0 +1,6 @@
+[semgrep]
+  [[semgrep.ruleset]]
+    disable = true
+    [semgrep.ruleset.identifier]
+      type = "eslint_rule_id"
+      value = "security/detect-object-injection"


### PR DESCRIPTION
1. Semgrep
The reasons is this rule basically flagging out all array[variable] and it is very noisy

**Refer to**
justification: https://github.com/GovTechSG/hivemind/discussions/328
report: https://sgts.gitlab-dedicated.com/wog/gvt/gds-ace/general/dlt/oa-as-a-service/oaas-issuer-dashboard/-/security/vulnerability_report

2. gitlab pipeline
The file contains the simplest step
```
stages:
- test
```

as the pipeline will be managed by the gitlab scan policy which will inject the tests accordingly