### PR TITLE
chore: add healthcert transient storage error message

### DIFF
--- a/pages/verify.tsx
+++ b/pages/verify.tsx
@@ -79,7 +79,7 @@ const Verify: NextPage<InferGetServerSidePropsType<typeof getServerSideProps>> =
             (isNotariseSpmTransientStorage(decodedQ.payload.uri) || isNotariseTransientStorage(decodedQ.payload.uri))
           ) {
             // Error component is customized in error-handler.tsx, hence message is empty
-            throw new CodedError("HealthCertsTransientBucketDecommError", "");
+            throw new CodedError("HealthCertsTransientStorageDecommError", "");
           }
 
           const document = await fetchAndDecryptDocument(

--- a/pages/verify.tsx
+++ b/pages/verify.tsx
@@ -12,6 +12,8 @@ import { verifyErrorHandler } from "@utils/error-handler";
 import { getUniversalActionType } from "@utils/get-universal-action-type";
 import { useUrlParamsThenScrubUrl } from "@utils/use-frag-then-scrub-url";
 import WogaaScript from "@components/layout/WogaaScript";
+import { isNotariseSpmTransientStorage, isNotariseTransientStorage } from "@utils/notarise-healthcerts";
+import { CodedError } from "@utils/coded-error";
 
 const Verifier = dynamic(() => import("@components/verify/Verifier"), { ssr: false });
 
@@ -47,6 +49,12 @@ const reducer: Reducer<State, Action> = (state, action) => {
   }
 };
 
+const isDecommTime = () => {
+  const currentDate = new Date();
+  const launchDate = new Date("05-01-2024 00:00:00 GMT+0800");
+  return currentDate >= launchDate;
+};
+
 const Verify: NextPage<InferGetServerSidePropsType<typeof getServerSideProps>> = (props) => {
   const initialState: State = {
     ...defaultState,
@@ -71,6 +79,15 @@ const Verify: NextPage<InferGetServerSidePropsType<typeof getServerSideProps>> =
           const encodedQ = typeof urlParams?.query.q === "string" ? urlParams.query.q : "";
           const encodedHash = urlParams?.uriFragment;
           const { decodedQ, decodedHash } = decodeQueryAndHash(encodedQ, encodedHash);
+
+          if (
+            isDecommTime() &&
+            (isNotariseSpmTransientStorage(decodedQ.payload.uri) || isNotariseTransientStorage(decodedQ.payload.uri))
+          ) {
+            // Error component is customized in error-handler.tsx, hence message is empty
+            throw new CodedError("HealthCertsTransientBucketDecommError", "");
+          }
+
           const document = await fetchAndDecryptDocument(
             decodedQ.payload.uri,
             decodedHash?.key || decodedQ.payload.key

--- a/pages/verify.tsx
+++ b/pages/verify.tsx
@@ -12,7 +12,7 @@ import { verifyErrorHandler } from "@utils/error-handler";
 import { getUniversalActionType } from "@utils/get-universal-action-type";
 import { useUrlParamsThenScrubUrl } from "@utils/use-frag-then-scrub-url";
 import WogaaScript from "@components/layout/WogaaScript";
-import { isNotariseSpmTransientStorage, isNotariseTransientStorage } from "@utils/notarise-healthcerts";
+import { isDecommTime, isNotariseSpmTransientStorage, isNotariseTransientStorage } from "@utils/notarise-healthcerts";
 import { CodedError } from "@utils/coded-error";
 
 const Verifier = dynamic(() => import("@components/verify/Verifier"), { ssr: false });
@@ -47,12 +47,6 @@ const reducer: Reducer<State, Action> = (state, action) => {
     default:
       return defaultState;
   }
-};
-
-const isDecommTime = () => {
-  const currentDate = new Date();
-  const launchDate = new Date("05-01-2024 00:00:00 GMT+0800");
-  return currentDate >= launchDate;
 };
 
 const Verify: NextPage<InferGetServerSidePropsType<typeof getServerSideProps>> = (props) => {

--- a/utils/coded-error.ts
+++ b/utils/coded-error.ts
@@ -4,7 +4,7 @@ enum ErrorType {
   DecryptionError,
   InvalidDocumentError,
   PermissionsError,
-  HealthCertsTransientBucketDecommError
+  HealthCertsTransientStorageDecommError,
 }
 
 type ErrorStrings = keyof typeof ErrorType;

--- a/utils/coded-error.ts
+++ b/utils/coded-error.ts
@@ -4,6 +4,7 @@ enum ErrorType {
   DecryptionError,
   InvalidDocumentError,
   PermissionsError,
+  HealthCertsTransientBucketDecommError
 }
 
 type ErrorStrings = keyof typeof ErrorType;

--- a/utils/error-handler.tsx
+++ b/utils/error-handler.tsx
@@ -10,7 +10,7 @@ import { StatusProps } from "@components/figure/StatusMessage";
  */
 export const verifyErrorHandler = (e: unknown): StatusProps => {
   if (e instanceof CodedError) {
-    if (e.type === "HealthCertsTransientBucketDecommError") {
+    if (e.type === "HealthCertsTransientStorageDecommError") {
       return {
         type: "ERROR",
         message: (

--- a/utils/error-handler.tsx
+++ b/utils/error-handler.tsx
@@ -10,6 +10,24 @@ import { StatusProps } from "@components/figure/StatusMessage";
  */
 export const verifyErrorHandler = (e: unknown): StatusProps => {
   if (e instanceof CodedError) {
+    if (e.type === "HealthCertsTransientBucketDecommError") {
+      return {
+        type: "ERROR",
+        message: (
+          <div className="flex flex-col lg:px-52">
+            <span className="font-semibold">Unable to fetch certificate</span>
+            <br />
+            <div>
+              As part of the Singapore government&apos;s efforts to streamline COVID operations, Notαrise will stop
+              issuing and hosting digital HealthCerts as of 1 May 2024.&nbsp;
+              <a href="https://notarise.gov.sg/faq" className="underline">
+                Learn more on your existing HealthCerts and other means of getting travel certificates.
+              </a>
+            </div>
+          </div>
+        ),
+      };
+    }
     return {
       type: "ERROR",
       message: (

--- a/utils/error-handler.tsx
+++ b/utils/error-handler.tsx
@@ -20,7 +20,7 @@ export const verifyErrorHandler = (e: unknown): StatusProps => {
             <div>
               As part of the Singapore government&apos;s efforts to streamline COVID operations, Notαrise will stop
               issuing and hosting digital HealthCerts as of 1 May 2024.&nbsp;
-              <a href="https://www.notarise.gov.sg/faq" className="underline">
+              <a href="https://www.notarise.gov.sg/faq" target="_blank" className="underline">
                 Learn more on your existing HealthCerts and other means of getting travel certificates.
               </a>
             </div>

--- a/utils/error-handler.tsx
+++ b/utils/error-handler.tsx
@@ -20,7 +20,7 @@ export const verifyErrorHandler = (e: unknown): StatusProps => {
             <div>
               As part of the Singapore government&apos;s efforts to streamline COVID operations, Notαrise will stop
               issuing and hosting digital HealthCerts as of 1 May 2024.&nbsp;
-              <a href="https://notarise.gov.sg/faq" className="underline">
+              <a href="https://www.notarise.gov.sg/faq" className="underline">
                 Learn more on your existing HealthCerts and other means of getting travel certificates.
               </a>
             </div>

--- a/utils/notarise-healthcerts.test.ts
+++ b/utils/notarise-healthcerts.test.ts
@@ -1,0 +1,36 @@
+import { isDecommTime } from "./notarise-healthcerts";
+
+const setJestSystemTime = (mockedDate: Date) => {
+  jest.useFakeTimers();
+  jest.setSystemTime(mockedDate);
+};
+
+describe("test isDecommTime", () => {
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it("should return false if current date is before the 1st May", () => {
+    const mockedDate = new Date("04-30-2024 23:59:59 GMT+0800");
+    setJestSystemTime(mockedDate);
+    expect(isDecommTime()).toBe(false);
+  });
+
+  it("should return true if current date is equal to 1st May", () => {
+    const mockedDate = new Date("05-01-2024 00:00:00 GMT+0800");
+    setJestSystemTime(mockedDate);
+    expect(isDecommTime()).toBe(true);
+  });
+
+  it("should return true if current date is 1 second after the 1st May", () => {
+    const mockedDate = new Date("05-02-2024 00:00:01 GMT+0800");
+    setJestSystemTime(mockedDate);
+    expect(isDecommTime()).toBe(true);
+  });
+
+  it("should return true if current date is one day after the 1st May", () => {
+    const mockedDate = new Date("05-02-2024 00:00:00 GMT+0800");
+    setJestSystemTime(mockedDate);
+    expect(isDecommTime()).toBe(true);
+  });
+});

--- a/utils/notarise-healthcerts.test.ts
+++ b/utils/notarise-healthcerts.test.ts
@@ -10,25 +10,25 @@ describe("test isDecommTime", () => {
     jest.useRealTimers();
   });
 
-  it("should return false if current date is before the 1st May", () => {
+  it("should return false if current date is before 1st May 2024", () => {
     const mockedDate = new Date("04-30-2024 23:59:59 GMT+0800");
     setJestSystemTime(mockedDate);
     expect(isDecommTime()).toBe(false);
   });
 
-  it("should return true if current date is equal to 1st May", () => {
+  it("should return true if current date is equal to 1st May 2024", () => {
     const mockedDate = new Date("05-01-2024 00:00:00 GMT+0800");
     setJestSystemTime(mockedDate);
     expect(isDecommTime()).toBe(true);
   });
 
-  it("should return true if current date is 1 second after the 1st May", () => {
-    const mockedDate = new Date("05-02-2024 00:00:01 GMT+0800");
+  it("should return true if current date is 1 second after 1st May 2024", () => {
+    const mockedDate = new Date("05-01-2024 00:00:01 GMT+0800");
     setJestSystemTime(mockedDate);
     expect(isDecommTime()).toBe(true);
   });
 
-  it("should return true if current date is one day after the 1st May", () => {
+  it("should return true if current date is one day after 1st May 2024", () => {
     const mockedDate = new Date("05-02-2024 00:00:00 GMT+0800");
     setJestSystemTime(mockedDate);
     expect(isDecommTime()).toBe(true);

--- a/utils/notarise-healthcerts.ts
+++ b/utils/notarise-healthcerts.ts
@@ -26,3 +26,9 @@ export const isNotariseSpmTransientStorage = (url = "") => {
     isNotariseTransientStorage(url) && notariseSpmTransientStoragePrefixes.some((prefix) => hostname.startsWith(prefix))
   );
 };
+
+export const isDecommTime = () => {
+  const currentDate = new Date();
+  const launchDate = new Date("05-01-2024 00:00:00 GMT+0800");
+  return currentDate >= launchDate;
+};

--- a/utils/notarise-healthcerts.ts
+++ b/utils/notarise-healthcerts.ts
@@ -29,6 +29,6 @@ export const isNotariseSpmTransientStorage = (url = "") => {
 
 export const isDecommTime = () => {
   const currentDate = new Date();
-  const launchDate = new Date("05-01-2024 00:00:00 GMT+0800");
-  return currentDate >= launchDate;
+  const decommDate = new Date("05-01-2024 00:00:00 GMT+0800");
+  return currentDate >= decommDate;
 };


### PR DESCRIPTION
## What this PR does
- Add error banner for HealthCerts using SPM or Notarise transient storage 
- To display the error only when certs are verified from a specific datetime onwards
- Add tests