### PR TITLE
chore: use correct env var

### DIFF
--- a/integration/multi-window-test/qr-barcode-scanner.spec.ts
+++ b/integration/multi-window-test/qr-barcode-scanner.spec.ts
@@ -36,7 +36,7 @@ test("Barcode scanner on QR page should be able to verify a valid QR", async (t)
   const action = {
     type: "DOCUMENT",
     payload: {
-      uri: "https://schemata.openattestation.com/sg/gov/moh/pdt-healthcert/2.0/endorsed-wrapped.json",
+      uri: "https://schemata.openattestation.com/sg/gov/moh/vaccination-healthcert/1.0/interim-vaccination-healthcert-wrapped.json",
       permittedActions: ["VIEW"],
       redirect: "https://www.verify.gov.sg/verify",
     },

--- a/integration/multi-window-test/qr-barcode-scanner.spec.ts
+++ b/integration/multi-window-test/qr-barcode-scanner.spec.ts
@@ -36,7 +36,7 @@ test("Barcode scanner on QR page should be able to verify a valid QR", async (t)
   const action = {
     type: "DOCUMENT",
     payload: {
-      uri: "https://schemata.openattestation.com/sg/gov/moh/vaccination-healthcert/1.0/interim-vaccination-healthcert-wrapped.json",
+      uri: "https://schemata.openattestation.com/sg/gov/moh/pdt-healthcert/2.0/endorsed-wrapped.json",
       permittedActions: ["VIEW"],
       redirect: "https://www.verify.gov.sg/verify",
     },

--- a/integration/multi-window-test/qr-barcode-scanner.spec.ts
+++ b/integration/multi-window-test/qr-barcode-scanner.spec.ts
@@ -36,7 +36,7 @@ test("Barcode scanner on QR page should be able to verify a valid QR", async (t)
   const action = {
     type: "DOCUMENT",
     payload: {
-      uri: "https://gallery.openattestation.com/static/documents/pdt-v2-art-healthcert.json",
+      uri: "https://gallery.openattestation.com/static/documents/pdt-v2-pcr-healthcert.json",
       permittedActions: ["VIEW"],
       redirect: "https://www.verify.gov.sg/verify",
     },

--- a/integration/multi-window-test/qr-barcode-scanner.spec.ts
+++ b/integration/multi-window-test/qr-barcode-scanner.spec.ts
@@ -36,7 +36,7 @@ test("Barcode scanner on QR page should be able to verify a valid QR", async (t)
   const action = {
     type: "DOCUMENT",
     payload: {
-      uri: "https://schemata.openattestation.com/sg/gov/moh/pdt-healthcert/2.0/endorsed-wrapped.json",
+      uri: "https://gallery.openattestation.com/static/documents/pdt-v2-art-healthcert.json",
       permittedActions: ["VIEW"],
       redirect: "https://www.verify.gov.sg/verify",
     },

--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,7 @@ const nextConfig = {
     // Computed env variables that are exposed to browser goes here:
     // https://nextjs.org/docs/app/api-reference/next-config-js/env
     BUILD_DATE: new Date().toISOString(),
+    SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
     // Other env variables can be set in .env or .env.production (https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#default-environment-variables)
   },
   headers: generateHeaders,


### PR DESCRIPTION
## What this PR does
- Add `SITE_URL` environment variable to reference `process.env.NEXT_PUBLIC_SITE_URL` in NextJS config

## Pending
- [x] To update the failing test URL to reference to the new document URL in https://github.com/Open-Attestation/gallery/pull/115