### PR TITLE
chore: install ethers@5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@govtechsg/sgds-masthead-react": "^0.0.11",
         "@types/lodash": "^4.14.194",
         "axios": "^1.6.2",
+        "ethers": "^5.7.2",
         "html5-qrcode": "^2.3.8",
         "isomorphic-fetch": "^3.0.0",
         "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@govtechsg/sgds-masthead-react": "^0.0.11",
     "@types/lodash": "^4.14.194",
     "axios": "^1.6.2",
+    "ethers": "^5.7.2",
     "html5-qrcode": "^2.3.8",
     "isomorphic-fetch": "^3.0.0",
     "lodash": "4.17.21",


### PR DESCRIPTION
## Context

* [This line imports ethers](https://github.com/Open-Attestation/verify.gov.sg/blob/772d635ea3ece50769855eb5769902f78e52b564/utils/oa-verify.ts#L15) but we dont have it in our package.json 

## What this PR does

* Install ethers v5 