### PR TITLE
chore: use masthead from sgds web comp module instead

### DIFF
--- a/components/layout/Masthead.tsx
+++ b/components/layout/Masthead.tsx
@@ -1,5 +1,4 @@
-import "@govtechsg/sgds-masthead/dist/sgds-masthead/sgds-masthead.css";
-import { SgdsMasthead } from "@govtechsg/sgds-masthead-react";
+import SgdsMasthead from "@govtechsg/sgds-web-component/react/masthead";
 
 const Masthead: React.FC = () => {
   return (

--- a/next.config.js
+++ b/next.config.js
@@ -14,7 +14,7 @@ const nextConfig = {
     // Other env variables can be set in .env or .env.production (https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#default-environment-variables)
   },
   headers: generateHeaders,
-  transpilePackages: ["@govtechsg/sgds-masthead-react"],
+  transpilePackages: ["@govtechsg/sgds-web-component/react/masthead"],
 };
 
 module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@govtechsg/oa-encryption": "^1.3.5",
         "@govtechsg/oa-verify": "^7.12.0",
         "@govtechsg/open-attestation": "^6.5.2",
-        "@govtechsg/sgds-masthead-react": "^0.0.11",
+        "@govtechsg/sgds-web-component": "^1.2.3",
         "@types/lodash": "^4.14.194",
         "axios": "^1.6.2",
         "ethers": "^5.7.2",
@@ -3551,9 +3551,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.24.1.tgz",
-      "integrity": "sha512-T9ko/35G+Bkl+win48GduaPlhSlOjjE5s1TeiEcD+QpxlLQnoEfb/nO/T+TQqkm+ipFwORn+rB8w14iJ/uD0bg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.24.7.tgz",
+      "integrity": "sha512-eytSX6JLBY6PVAeQa2bFlDx/7Mmln/gaEpsit5a3WEvjGfiIytEsgAwuIXCPM0xvw0v0cJn3ilq0/TvXrW0kgA==",
       "dependencies": {
         "core-js-pure": "^3.30.2",
         "regenerator-runtime": "^0.14.0"
@@ -5324,26 +5324,44 @@
         "validator": "^13.7.0"
       }
     },
-    "node_modules/@govtechsg/sgds-masthead": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@govtechsg/sgds-masthead/-/sgds-masthead-0.0.18.tgz",
-      "integrity": "sha512-vBOw7yHNc1HBWj0a0sxhjTVzHPz2fiMYdLe2BJNaRqys86OnXQ516k4+4J3VBdJTQLTG4ytfPFeGbhePtoZXUg==",
-      "deprecated": "This package is no loger supported. We recommend using @govtechsg/sgds-web-component  instead.",
+    "node_modules/@govtechsg/sgds": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@govtechsg/sgds/-/sgds-2.3.3.tgz",
+      "integrity": "sha512-hZ7AeMbPFfQlvjuAPnLZ7g9Th/2y7x1kAZ0T3NbMN5pm4RiZDlLz0jj5jw1f/2T1HnqCp8t4f9NT+H9r5HUrUg==",
       "dependencies": {
-        "@stencil/core": "^2.13.0"
+        "bootstrap": "5.1.3"
       }
     },
-    "node_modules/@govtechsg/sgds-masthead-react": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@govtechsg/sgds-masthead-react/-/sgds-masthead-react-0.0.11.tgz",
-      "integrity": "sha512-+ghexQrVSwwWwP5Zb2lo4/VUIZ1KDDjuIz2M/h9dTuXoDKQymj0aV+Q+JnJUCcDTBCZybA4HncLI93RKk6Xqjw==",
-      "deprecated": "This package is no loger supported. We recommend using @govtechsg/sgds-web-component instead.",
+    "node_modules/@govtechsg/sgds-web-component": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@govtechsg/sgds-web-component/-/sgds-web-component-1.2.3.tgz",
+      "integrity": "sha512-8J8SFaiiLfVNu//RpKDZd3TczyL+wjF1DzZxzR3TCucJXWlT05MciLuG3I7x1QyI1FKMMlw3+dZtMbjmrkvh1g==",
       "dependencies": {
-        "@govtechsg/sgds-masthead": "^0.0.18"
+        "@govtechsg/sgds": "^2.3.2",
+        "@lit-labs/react": "^1.0.9",
+        "@open-wc/scoped-elements": "^2.2.0",
+        "bootstrap": "^5.1.3",
+        "date-fns": "^3.3.1",
+        "imask": "^7.4.0",
+        "lit": "^2.3.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@govtechsg/sgds-web-component/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+    },
+    "node_modules/@govtechsg/sgds/node_modules/bootstrap": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bootstrap"
       },
       "peerDependencies": {
-        "react": ">=17.0.2",
-        "react-dom": ">=17.0.2"
+        "@popperjs/core": "^2.10.2"
       }
     },
     "node_modules/@govtechsg/token-registry": {
@@ -5978,6 +5996,24 @@
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
+    "node_modules/@lit-labs/react": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.2.1.tgz",
+      "integrity": "sha512-DiZdJYFU0tBbdQkfwwRSwYyI/mcWkg3sWesKRsHUd4G+NekTmmeq9fzsurvcKTNVa0comNljwtg4Hvi1ds3V+A=="
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
+      "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
+    },
     "node_modules/@ls-age/commitlint-circle": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@ls-age/commitlint-circle/-/commitlint-circle-1.0.0.tgz",
@@ -6404,6 +6440,20 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@open-wc/dedupe-mixin": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
+      "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA=="
+    },
+    "node_modules/@open-wc/scoped-elements": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-2.2.4.tgz",
+      "integrity": "sha512-12X4F4QGPWcvPbxAiJ4v8wQFCOu+laZHRGfTrkoj+3JzACCtuxHG49YbuqVzQ135QPKCuhP9wA0kpGGEfUegyg==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.0.0 || ^2.0.0",
+        "@open-wc/dedupe-mixin": "^1.4.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -7855,18 +7905,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
-    "node_modules/@stencil/core": {
-      "version": "2.22.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
-      "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng==",
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/@swc/helpers": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
@@ -8389,6 +8427,11 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
     },
     "node_modules/@types/unist": {
       "version": "2.0.10",
@@ -9686,6 +9729,24 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
     },
     "node_modules/bowser": {
       "version": "2.11.0",
@@ -11140,6 +11201,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dayjs": {
@@ -14519,6 +14589,17 @@
         "node": ">= 4"
       }
     },
+    "node_modules/imask": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/imask/-/imask-7.6.1.tgz",
+      "integrity": "sha512-sJlIFM7eathUEMChTh9Mrfw/IgiWgJqBKq2VNbyXvBZ7ev/IlO6/KQTKlV/Fm+viQMLrFLG/zCuudrLIwgK2dg==",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.24.4"
+      },
+      "engines": {
+        "npm": ">=4.0.0"
+      }
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -17011,6 +17092,50 @@
       "dev": true,
       "dependencies": {
         "os-family": "^1.0.0"
+      }
+    },
+    "node_modules/lit": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/lit-element/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/lit/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "node_modules/loader-utils": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@govtechsg/oa-encryption": "^1.3.5",
     "@govtechsg/oa-verify": "^7.12.0",
     "@govtechsg/open-attestation": "^6.5.2",
-    "@govtechsg/sgds-masthead-react": "^0.0.11",
+    "@govtechsg/sgds-web-component": "^1.2.3",
     "@types/lodash": "^4.14.194",
     "axios": "^1.6.2",
     "ethers": "^5.7.2",

--- a/utils/google-analytics.ts
+++ b/utils/google-analytics.ts
@@ -45,7 +45,7 @@ export const getDocumentType = (data: OpenAttestationDocument): DOCUMENT_TYPE =>
 export const useGoogleAnalytics = (): void => {
   useEffect(() => {
     try {
-      const GTAG_ID = process.env.NEXT_PUBLIC_GTAG_ID;
+      const GTAG_ID = process.env.NEXT_PUBLIC_GTAG_ID || "G-40G8RLK2GF"
       if (GTAG_ID?.startsWith("G-")) {
         ReactGA.initialize(GTAG_ID);
         ReactGA.send("pageview");


### PR DESCRIPTION
## Why
`@govtechsg/sgds-masthead-react` is deprecated

## What
Use `@govtechsg/sgds-web-component` instead of `@govtechsg/sgds-masthead-react`