### PR TITLE
feat: add ga tracking for print

### DIFF
--- a/components/figure/Renderer.tsx
+++ b/components/figure/Renderer.tsx
@@ -69,7 +69,7 @@ const Renderer: React.FC<RendererProps> = ({ document, rawDocument }) => {
         "Printing this document is not optimised on your device.\nFor the best result, use: \n- Chrome on Android devices \n- Safari on IOS devices \n- Any major browsers on desktop"
       );
     }
-    sendCertificatePrintEvent(document);
+    sendCertificatePrintEvent(document, { isSupportedBrowser: !isUnsupportedBrowser });
     toFrame && toFrame(print());
   }, [document, toFrame]);
 

--- a/components/figure/Renderer.tsx
+++ b/components/figure/Renderer.tsx
@@ -16,6 +16,7 @@ import { faPrint } from "@fortawesome/free-solid-svg-icons";
 
 import { getTemplateUrl } from "@utils/oa-details";
 import { OpenAttestationDocument, WrappedDocument } from "@govtechsg/open-attestation";
+import { sendCertificatePrintEvent } from "@utils/google-analytics";
 
 /* Workaround for undefined window object: Dynamic import so FrameConnector will not load on server-side */
 // FIXME: Weird type error occurs without dynamic<any> (i.e. type error occurs when you do not specify props type for FrameConnector)
@@ -68,8 +69,9 @@ const Renderer: React.FC<RendererProps> = ({ document, rawDocument }) => {
         "Printing this document is not optimised on your device.\nFor the best result, use: \n- Chrome on Android devices \n- Safari on IOS devices \n- Any major browsers on desktop"
       );
     }
+    sendCertificatePrintEvent(document);
     toFrame && toFrame(print());
-  }, [toFrame]);
+  }, [document, toFrame]);
 
   const handleTemplateSelection = useCallback(
     (template: Template) => () => {

--- a/utils/google-analytics.test.tsx
+++ b/utils/google-analytics.test.tsx
@@ -10,6 +10,7 @@ import {
   useGoogleAnalytics,
   sendSuccessfulVerificationEvent,
   sendUnsuccessfulVerificationEvent,
+  sendCertificatePrintEvent,
 } from "@utils/google-analytics";
 import { isHealthCert } from "@utils/notarise-healthcerts";
 import pdt_v1 from "@utils/fixtures/pdt_v1_healthcert.json";
@@ -77,6 +78,35 @@ describe("test getHealthCertType() util function", () => {
 });
 
 describe("sendHealthCertVerifiedEvent and sendHealthCertErrorEvent", () => {
+  it("sendCertificatePrintEvent should send document id, type and browser support", () => {
+    const data = getData(pdt_v2 as any);
+    const spy = jest.spyOn(ReactGA, "event");
+    sendCertificatePrintEvent(data, { isSupportedBrowser: true });
+    expect(spy).toHaveBeenCalledWith(EVENT_CATEGORY.PRINT, {
+      document_id: "9867890e-6ad8-4735-b705-1ccd441984f8",
+      document_type: DOCUMENT_TYPE.PDT,
+      issuer_name: "SAMPLE CLINIC",
+      issuer_identity_location: "donotverify.testing.verify.gov.sg",
+      template_name: "HEALTH_CERT",
+      template_url: "https://healthcert.renderer.moh.gov.sg/",
+      supported_browser: true,
+    });
+  });
+
+  it("sendCertificatePrintEvent should send document id and type without browser support when not specified", () => {
+    const data = getData(pdt_v2 as any);
+    const spy = jest.spyOn(ReactGA, "event");
+    sendCertificatePrintEvent(data);
+    expect(spy).toHaveBeenCalledWith(EVENT_CATEGORY.PRINT, {
+      document_id: "9867890e-6ad8-4735-b705-1ccd441984f8",
+      document_type: DOCUMENT_TYPE.PDT,
+      issuer_name: "SAMPLE CLINIC",
+      issuer_identity_location: "donotverify.testing.verify.gov.sg",
+      template_name: "HEALTH_CERT",
+      template_url: "https://healthcert.renderer.moh.gov.sg/",
+    });
+  });
+
   it("sendHealthCertVerifiedEvent should send document id and type", () => {
     const data = getData(pdt_v2 as any);
     const spy = jest.spyOn(ReactGA, "event");

--- a/utils/google-analytics.ts
+++ b/utils/google-analytics.ts
@@ -17,6 +17,7 @@ export enum DOCUMENT_TYPE {
 export enum EVENT_CATEGORY {
   VERIFIED = "certificate_verified",
   ERROR = "certificate_error",
+  PRINT = "certificate_print",
 }
 
 export const getDocumentType = (data: OpenAttestationDocument): DOCUMENT_TYPE => {
@@ -55,6 +56,23 @@ export const useGoogleAnalytics = (): void => {
     }
   }, []);
 };
+
+export const sendCertificatePrintEvent = (data: OpenAttestationDocument): void => {
+  if (utils.isRawV3Document(data)) return; // OA v3 currently not supported by verify.gov.sg
+
+  try {
+    ReactGA.event(EVENT_CATEGORY.PRINT, {
+      document_id: data.id || "",
+      document_type: getDocumentType(data),
+      issuer_name: data.issuers[0].name || "",
+      issuer_identity_location: data.issuers[0].identityProof?.location || "",
+      template_name: typeof data.$template === "string" ? data.$template : data.$template?.name || "",
+      template_url: typeof data.$template === "string" ? data.$template : data.$template?.url || "",
+    });
+  } catch (e) {
+    console.error(e);
+  }
+}
 
 export const sendSuccessfulVerificationEvent = (data: OpenAttestationDocument): void => {
   if (utils.isRawV3Document(data)) return; // OA v3 currently not supported by verify.gov.sg


### PR DESCRIPTION
## Summary

Add GA tracking to the print button in the certificate viewer. 

## Changes
- Add GA tracking to the print button
- Refactor the send GA event functions

## Issues
- https://sgts.gitlab-dedicated.com/wog/gvt/gds-ace/general/dlt/galaxies-stories/trustdocs-stories/-/issues/301