### PR TITLE
feat: update whitelist for QR origins

### DIFF
--- a/pages/qr.tsx
+++ b/pages/qr.tsx
@@ -87,7 +87,12 @@ const Qr: NextPage = () => {
     try {
       const parsedUrl = new URL(url);
       const SITE_URL = process.env.SITE_URL; // See "next.config.js"
-      const allowedOrigins = [SITE_URL, "https://www.verify.gov.sg"];
+      const allowedOrigins = [
+        SITE_URL,
+        "https://action.openattestation.com",
+        "https://www.verify.gov.sg",
+        "https://www.trustdocs.gov.sg",
+      ];
 
       if (!allowedOrigins.some((origin) => origin === parsedUrl.origin)) {
         throw new CodedError("InvalidDocumentError", "Invalid Verify QR, please try again");

--- a/pages/qr.tsx
+++ b/pages/qr.tsx
@@ -90,7 +90,9 @@ const Qr: NextPage = () => {
       const allowedOrigins = [
         SITE_URL,
         "https://action.openattestation.com",
+        "https://verify.gov.sg",
         "https://www.verify.gov.sg",
+        "https://trustdocs.gov.sg",
         "https://www.trustdocs.gov.sg",
       ];
 


### PR DESCRIPTION
Allow `https://www.trustdocs.gov.sg` and `https://action.openattestation.com` origins